### PR TITLE
use a define to control whether hitboxes are drawn, instead of a global var

### DIFF
--- a/Character.cpp
+++ b/Character.cpp
@@ -279,7 +279,7 @@ void Character::draw(Arduboy2 &arduboy)
     Sprites::drawSelfMasked(x, y, currentSprite, currentFrame);
   }
 
-  if (debugDraw) {
-    arduboy.drawCircle(x + PLAYER_HALF_W, y + PLAYER_HALF_H, PLAYER_HALF_W);
-  }
+#ifdef DEBUG_DRAW_HITBOXES
+    arduboy.drawCircle(getCenterX(), getCenterY(), radius);
+#endif
 }

--- a/Entity_Enemy.cpp
+++ b/Entity_Enemy.cpp
@@ -39,7 +39,7 @@ void Entity_Enemy::draw(Arduboy2 &arduboy) {
     Sprites::drawSelfMasked(getAbsoluteX(), y, enemy_spider, 0);
   }
 
-  if (debugDraw) {
+#ifdef DEBUG_DRAW_HITBOXES
     arduboy.drawCircle(getCollisionX(), getCollisionY(), getCollisionR());
-  }
+#endif
 }

--- a/GameState_Play.cpp
+++ b/GameState_Play.cpp
@@ -14,7 +14,6 @@ float speedMultiplierIncreasePerFrame = (maxSpeed - globalSpeedMultiplier) / (ti
 bool autoSpeedupEnabled = true;
 
 bool godModeEnabled = false;
-bool debugDraw  = false;
 
 void GameState_Play::init() {
     godModeEnabled = false;

--- a/Vars.h
+++ b/Vars.h
@@ -4,6 +4,8 @@
 
 #include <avr/pgmspace.h>
 
+//#define DEBUG_DRAW_HITBOXES
+
 #define PLAYER_W 16
 #define PLAYER_HALF_W 8
 #define PLAYER_H 32
@@ -116,7 +118,6 @@ extern int lives;
 extern int score;
 extern float globalSpeedMultiplier;
 extern bool godModeEnabled;
-extern bool debugDraw;
 
 #endif // VARS_H
 


### PR DESCRIPTION
this helps completely strip the drawCircle stuff out of builds that don't need it