### PR TITLE
only create as many ground entities as we need

### DIFF
--- a/Character.h
+++ b/Character.h
@@ -5,7 +5,7 @@
 #include "sprites.h"
 #include <Arduboy2.h>
 
-enum CharacterType {
+enum CharacterType : uint8_t {
   JONAS,
   HENRY,
   MASON,
@@ -14,7 +14,7 @@ enum CharacterType {
   NOLA,
 };
 
-enum CharacterState {
+enum CharacterState : uint8_t {
     IDLE,
     WALK,
     JUMP,

--- a/Entity.h
+++ b/Entity.h
@@ -3,7 +3,7 @@
 
 #include <Arduboy2.h>
 
-enum EntityType {
+enum EntityType : uint8_t {
     GROUND,
     COIN,
     ENEMY,

--- a/EntityManager.cpp
+++ b/EntityManager.cpp
@@ -42,7 +42,7 @@ void EntityManager::cleanup() {
         // Check if the pointer is not null
         if (entities[i] != nullptr) {
             // Delete the entity object
-            delete entities[i];
+            //delete entities[i];// don't delete, these are managed elsewhere!
 
             // Set the pointer to null to avoid dangling references
             entities[i] = nullptr;

--- a/EntityManager_Ground.cpp
+++ b/EntityManager_Ground.cpp
@@ -25,6 +25,9 @@ void EntityManager_Ground::recycleGroundEntity(int index) {
     if (entities[index] != nullptr && entities[index]->getEntityType() == EntityType::GROUND) {
         Entity_Ground* groundEntity = static_cast<Entity_Ground*>(entities[index]);
         groundEntity->setX(maxRightX);
+
+        // pick a new random section
+        groundEntity->setData(&groundDefinitions[random(0, GROUND_DEFINITION_COUNT)]);
     }
 }
 

--- a/Entity_Enemy.cpp
+++ b/Entity_Enemy.cpp
@@ -36,9 +36,9 @@ void Entity_Enemy::update(float newX) {
 void Entity_Enemy::draw(Arduboy2 &arduboy) {
 
   if (enemyType == EnemyType::TROLL) {
-    Sprites::drawSelfMasked(getAbsoluteX(), y, enemy_troll, 0);
+    Sprites::drawSelfMasked(getAbsoluteX(), 28, enemy_troll, 0);
   } else if (enemyType == EnemyType::SPIDER) {
-    Sprites::drawSelfMasked(getAbsoluteX(), y, enemy_spider, 0);
+    Sprites::drawSelfMasked(getAbsoluteX(), 0, enemy_spider, 0);
   }
 
 #ifdef DEBUG_DRAW_HITBOXES

--- a/Entity_Enemy.cpp
+++ b/Entity_Enemy.cpp
@@ -1,9 +1,14 @@
 // Entity_Ground.cpp
 #include "Entity_Enemy.h"
 
-Entity_Enemy::Entity_Enemy(const EnemyDefinition& enemyDefinition, float groundX): Entity()
+Entity_Enemy::Entity_Enemy() : Entity()
 {
-    EnemyTypeDefinition enemyTypeDefinition = getEnemyTypeDefinition();
+
+}
+
+void Entity_Enemy::setData(const EnemyDefinition& enemyDefinition, float groundX)
+{
+    const EnemyTypeDefinition& enemyTypeDefinition = getEnemyTypeDefinition();
 
     x = enemyDefinition.x;
     xRaw = x;
@@ -30,10 +35,19 @@ int Entity_Enemy::getCollisionY() {
 }
 
 void Entity_Enemy::update(float newX) {
+  if (!enabled)
+  {
+    return;
+  }
+
   offsetX = newX;
 }
 
 void Entity_Enemy::draw(Arduboy2 &arduboy) {
+  if (!enabled)
+  {
+    return;
+  }
 
   if (enemyType == EnemyType::TROLL) {
     Sprites::drawSelfMasked(getAbsoluteX(), 28, enemy_troll, 0);

--- a/Entity_Enemy.h
+++ b/Entity_Enemy.h
@@ -10,7 +10,8 @@
 class Entity_Enemy : public Entity {
 
 public:
-    Entity_Enemy(const EnemyDefinition& enemyDefinition, float groundX);
+    Entity_Enemy();
+    void setData(const EnemyDefinition& enemyDefinition, float groundX);
 
     void update(float newX);
     void draw(Arduboy2 &arduboy) override;
@@ -19,12 +20,14 @@ public:
     int getCollisionX();
     int getCollisionY();
 
-    EnemyTypeDefinition getEnemyTypeDefinition() { return enemyTypeDefinitions[enemyType]; }
+    const EnemyTypeDefinition& getEnemyTypeDefinition() { return enemyTypeDefinitions[enemyType]; }
     int getColliderX() { return getEnemyTypeDefinition().colliderX; }
     int getColliderY() { return getEnemyTypeDefinition().colliderY; }
     int getColliderRadius() { return getEnemyTypeDefinition().colliderRadius; }
 
     EnemyType enemyType;
+
+    bool enabled;
 
 private:
     int offsetX;

--- a/Entity_Ground.h
+++ b/Entity_Ground.h
@@ -11,22 +11,22 @@
 class Entity_Ground : public Entity {
 public:
     Entity_Ground();
-    Entity_Ground(int initialX, int initialY, int arrayIndex);
+    void init(int initialX, int initialY);
     ~Entity_Ground();
+
+    void setData(SegmentDefinition * segmentDefinition);
 
     void update() override;
     void draw(Arduboy2 &arduboy) override;
 
     void drawEnemies(Arduboy2 &arduboy);
     bool isGroundAt(int posX);
-    void addEnemy(const EnemyDefinition& enemyDefinition);
     bool enemyCollision(int playerX, int playerY, int playerRadius);
 
 private:
     uint8_t groundTiles[GROUND_DEFINITION_SIZE];
 
-    Entity_Enemy* enemyArray[MAX_ENEMIES_PER_SEGMENT]; // Array of pointers to Entity_Enemy
-    int numEnemies;
+    Entity_Enemy* enemies[MAX_ENEMIES_PER_SEGMENT]; // Array of pointers to Entity_Enemy
 
     CoinDefinition coinArray[MAX_COINS_PER_SEGMENT];
     int numCoins;

--- a/GameStateId.h
+++ b/GameStateId.h
@@ -1,4 +1,4 @@
-enum GameStateID {
+enum GameStateID : uint8_t {
     STATE_START_MENU,
     STATE_CHARACTER_SELECTION,
     STATE_GAME_PLAY,

--- a/GameState_Play.cpp
+++ b/GameState_Play.cpp
@@ -79,9 +79,7 @@ void GameState_Play::update(Arduboy2 &arduboy) {
 
     // Update logic
     if (arduboy.justPressed(B_BUTTON)) {
-      if (stateChangeCallback != nullptr) {
-          stateChangeCallback(STATE_START_MENU);
-      }
+      stateChangeCallback(STATE_START_MENU);
     }
 
     cameraX = -speed * globalSpeedMultiplier;

--- a/GameState_Play.cpp
+++ b/GameState_Play.cpp
@@ -18,6 +18,9 @@ bool autoSpeedupEnabled = true;
 
 bool godModeEnabled = false;
 
+#define MAX_VISIBLE_GROUND_PIECES 3
+Entity_Ground groundPieces[MAX_VISIBLE_GROUND_PIECES];
+
 void GameState_Play::init() {
     godModeEnabled = false;
 
@@ -107,13 +110,17 @@ void GameState_Play::update(Arduboy2 &arduboy) {
     playerCharacter->update(arduboy);
 }
 
-void GameState_Play::createGroundEntities() {
-  
+void GameState_Play::createGroundEntities()
+{
+  // create as many ground entities as can possibly be visible at once.
   int lastX = 0;
-  for (int i = 0; i < GROUND_DEFINITION_COUNT; i++) {
-    Entity_Ground* newGround = new Entity_Ground(lastX, 60, i);
-    groundManager.addEntity(newGround);
+  for (int i = 0; i < MAX_VISIBLE_GROUND_PIECES; i++)
+  {
+    Entity_Ground* groundEntity = &groundPieces[i];
+    groundEntity->init(lastX, 60);
+    groundManager.addEntity(groundEntity);
     lastX += GROUND_DEFINITION_SIZE * GROUND_SIZE;
+    groundEntity->setData(&groundDefinitions[random(0, GROUND_DEFINITION_COUNT)]);
   }
   
 }
@@ -124,11 +131,13 @@ void GameState_Play::draw(Arduboy2 &arduboy) {
     playerCharacter->draw(arduboy);
 }
 
-void GameState_Play::cleanup() {
-     if (playerCharacter != nullptr) {
-        delete playerCharacter;
-        playerCharacter = nullptr; // Set to nullptr to avoid dangling pointer
-    }
-    // Drawing code
-    groundManager.cleanup();
+void GameState_Play::cleanup()
+{
+  if (playerCharacter != nullptr)
+  {
+    delete playerCharacter;
+    playerCharacter = nullptr; // Set to nullptr to avoid dangling pointer
+  }
+
+  groundManager.cleanup();
 }

--- a/GameState_Titlescreen.cpp
+++ b/GameState_Titlescreen.cpp
@@ -14,9 +14,7 @@ void GameState_Titlescreen::init() {
 void GameState_Titlescreen::update(Arduboy2 &arduboy) {
     // Update logic
     if (arduboy.justReleased(A_BUTTON)) {
-        if (stateChangeCallback != nullptr) {
-            stateChangeCallback(STATE_CHARACTER_SELECTION);
-        }
+      stateChangeCallback(STATE_CHARACTER_SELECTION);
     }
 }
 

--- a/SegmentDefinition.h
+++ b/SegmentDefinition.h
@@ -20,7 +20,7 @@ struct EnemyTypeDefinition {
 };
 
 // !!! the EnemyType enum and the enemyDefinitions must be in the same order!
-enum EnemyType {
+enum EnemyType : uint8_t {
     NONE,
     TROLL,
     SPIDER,
@@ -68,16 +68,17 @@ struct SegmentDefinition {
 const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {
         // segment 0
         {
-                {255, 255, 195},
+                {255, 255, 255},
                 {
-
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
                 },
                 {
                 }
         },
         // segment 1
         {
-                {127, 248, 176},
+                {255, 7, 224},
                 {
                 },
                 {

--- a/SegmentDefinition.h
+++ b/SegmentDefinition.h
@@ -64,8 +64,152 @@ struct SegmentDefinition {
 };
 
 // change this if you add/remove groundDefinitions.
-#define GROUND_DEFINITION_COUNT 4
+#define GROUND_DEFINITION_COUNT 20
 const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
         // segment 0
         {
                 {255, 255, 255},

--- a/SegmentDefinition.h
+++ b/SegmentDefinition.h
@@ -64,7 +64,7 @@ struct SegmentDefinition {
 };
 
 // change this if you add/remove groundDefinitions.
-#define GROUND_DEFINITION_COUNT 2
+#define GROUND_DEFINITION_COUNT 4
 const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {
         // segment 0
         {
@@ -79,6 +79,24 @@ const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {
         // segment 1
         {
                 {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
                 {
                 },
                 {

--- a/SegmentDefinition.h
+++ b/SegmentDefinition.h
@@ -64,8 +64,188 @@ struct SegmentDefinition {
 };
 
 // change this if you add/remove groundDefinitions.
-#define GROUND_DEFINITION_COUNT 20
+#define GROUND_DEFINITION_COUNT 40
 const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
+        // segment 0
+        {
+                {255, 255, 255},
+                {
+                        {2, 48}, // Enemy
+                        {1, 113}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 1
+        {
+                {255, 7, 224},
+                {
+                },
+                {
+                }
+        },
+        // segment 2
+        {
+                {255, 255, 255},
+                {
+                        {2, 12}, // Enemy
+                        {2, 36}, // Enemy
+                },
+                {
+                }
+        },
+        // segment 3
+        {
+                {255, 255, 255},
+                {
+                },
+                {
+                }
+        },
         // segment 0
         {
                 {255, 255, 255},

--- a/Vars.h
+++ b/Vars.h
@@ -6,7 +6,7 @@
 
 #include "SegmentDefinition.h"
 
-//#define DEBUG_DRAW_HITBOXES
+#define DEBUG_DRAW_HITBOXES
 
 #define PLAYER_W 16
 #define PLAYER_H 32

--- a/arduboy-birthday-game.ino
+++ b/arduboy-birthday-game.ino
@@ -15,14 +15,6 @@ GameState_Titlescreen startMenuState;
 GameState_CharacterSelection characterSelectionState;
 GameState_Play gamePlayState;
 
-GameState* gameStates[] = {
-  &startMenuState,
-  &characterSelectionState,
-  &gamePlayState
-};
-
-const int numGameStates = sizeof(gameStates) / sizeof(gameStates[0]);
-
 void setup() {
   
   Serial.begin(9600);
@@ -30,9 +22,9 @@ void setup() {
   arduboy.boot();
   arduboy.setFrameRate(60);
 
-  for (int i = 0; i < numGameStates; i++) {
-    gameStates[i]->setStateChangeCallback(changeGameState);
-  }
+  startMenuState.setStateChangeCallback(changeGameState);
+  characterSelectionState.setStateChangeCallback(changeGameState);
+  gamePlayState.setStateChangeCallback(changeGameState);
 
   stateManager.setState(&startMenuState);
 }


### PR DESCRIPTION
only creating 3 Entity_Grounds now, which are fed different data when they are moved back to the end.
this also creates all 3 enemies up front too, which are also fed different data when the ground is reinitialized with new data.

I've tested this with 20 sections in the SegmentDefinition.h and no crashing

there's also some smaller optimizations here too but pretty minor in comparison