### PR TITLE
guarantee that the first section is solid ground

### DIFF
--- a/GameState_Play.cpp
+++ b/GameState_Play.cpp
@@ -120,7 +120,11 @@ void GameState_Play::createGroundEntities()
     groundEntity->init(lastX, 60);
     groundManager.addEntity(groundEntity);
     lastX += GROUND_DEFINITION_SIZE * GROUND_SIZE;
-    groundEntity->setData(&groundDefinitions[random(0, GROUND_DEFINITION_COUNT)]);
+    groundEntity->setData(
+            i == 0
+            ? &flatGround
+            : &groundDefinitions[random(0, GROUND_DEFINITION_COUNT)]
+      );
   }
   
 }

--- a/SegmentDefinition.h
+++ b/SegmentDefinition.h
@@ -63,6 +63,10 @@ struct SegmentDefinition {
     CoinDefinition coins[MAX_COINS_PER_SEGMENT];       // Define MAX_COINS_PER_SEGMENT as needed
 };
 
+const SegmentDefinition flatGround PROGMEM = {
+        {255, 255, 255}, {}, {}
+};
+
 // change this if you add/remove groundDefinitions.
 #define GROUND_DEFINITION_COUNT 40
 const SegmentDefinition groundDefinitions[GROUND_DEFINITION_COUNT] PROGMEM = {


### PR DESCRIPTION
this guarantees you aren't going to spawn on top of an enemy.

we pay a little extra memory for this.  

I think we could leverage this special segment definition to add a little bit of a cooldown periodically. like every 10 sections they beat, throw a flat ground at them.